### PR TITLE
Removed set_index() deprecated method. Used to_csv cuDF method

### DIFF
--- a/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
+++ b/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
@@ -220,7 +220,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can create a new column with a different index by using the `set_index` method."
+    "We can change the index of the `Series` by setting the `index` property."
    ]
   },
   {
@@ -241,8 +241,8 @@
     }
    ],
    "source": [
-    "new_column = column.set_index([5, 6, 7, 8]) \n",
-    "print(new_column)"
+    "column.index = [5, 6, 7, 8] \n",
+    "column"
    ]
   },
   {
@@ -1004,7 +1004,7 @@
    "source": [
     "#### Writing and Loading CSV Files\n",
     "\n",
-    "At this time, there is no direct way to use to cuDF to write directly to CSV. However, we can conver the cuDF DataFrame to a Pandas DataFrame and then write it directly to a CSV."
+    "We can write a cuDF DataFrame to a CSV file using the `to_csv()` method."
    ]
   },
   {
@@ -1013,7 +1013,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.to_pandas().to_csv('./dataset.csv', index=False)"
+    "df.to_csv('./dataset.csv', index=False)"
    ]
   },
   {


### PR DESCRIPTION
The Series method `set_index()` is not available anymore. I have updated cell #7 to reflect it.
Also, cuDF already supports `to_csv()` method. I have updated the notebook accordingly.