### PR TITLE
Use Series apply instead of applymap in cuDF intro notebook

### DIFF
--- a/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
+++ b/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
@@ -42,48 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mon Sep 19 17:00:40 2022       \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| NVIDIA-SMI 495.29.05    Driver Version: 495.29.05    CUDA Version: 11.5     |\n",
-      "|-------------------------------+----------------------+----------------------+\n",
-      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
-      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
-      "|                               |                      |               MIG M. |\n",
-      "|===============================+======================+======================|\n",
-      "|   0  Quadro RTX 8000     Off  | 00000000:15:00.0 Off |                  Off |\n",
-      "| 33%   29C    P8    11W / 260W |    508MiB / 48601MiB |      0%      Default |\n",
-      "|                               |                      |                  N/A |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "|   1  Quadro RTX 8000     Off  | 00000000:2D:00.0  On |                  Off |\n",
-      "| 33%   38C    P8    35W / 260W |    549MiB / 48598MiB |     44%      Default |\n",
-      "|                               |                      |                  N/A |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "                                                                               \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| Processes:                                                                  |\n",
-      "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
-      "|        ID   ID                                                   Usage      |\n",
-      "|=============================================================================|\n",
-      "|    0   N/A  N/A      1021      G   /usr/lib/xorg/Xorg                  4MiB |\n",
-      "|    0   N/A  N/A      2354      G   /usr/lib/xorg/Xorg                  4MiB |\n",
-      "|    0   N/A  N/A      6919      C   ...s/rapids-22.08/bin/python      495MiB |\n",
-      "|    1   N/A  N/A      1021      G   /usr/lib/xorg/Xorg                 39MiB |\n",
-      "|    1   N/A  N/A      2354      G   /usr/lib/xorg/Xorg                155MiB |\n",
-      "|    1   N/A  N/A      2479      G   /usr/bin/gnome-shell               41MiB |\n",
-      "|    1   N/A  N/A      2944      G   /usr/lib/firefox/firefox          168MiB |\n",
-      "|    1   N/A  N/A      5957      G   ...veSuggestionsOnlyOnDemand       92MiB |\n",
-      "|    1   N/A  N/A     19040      G   ...RendererForSitePerProcess       37MiB |\n",
-      "+-----------------------------------------------------------------------------+\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!nvidia-smi"
    ]
@@ -97,21 +58,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "nvcc: NVIDIA (R) Cuda compiler driver\n",
-      "Copyright (c) 2005-2021 NVIDIA Corporation\n",
-      "Built on Mon_Sep_13_19:13:29_PDT_2021\n",
-      "Cuda compilation tools, release 11.5, V11.5.50\n",
-      "Build cuda_11.5.r11.5/compiler.30411180_0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!nvcc --version"
    ]
@@ -128,17 +77,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cuDF Version: 22.10.00a+280.ge5636c83c3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import cudf; print('cuDF Version:', cudf.__version__)"
    ]
@@ -154,24 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    10\n",
-       "1    11\n",
-       "2    12\n",
-       "3    13\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "column = cudf.Series([10, 11, 12, 13])\n",
     "column"
@@ -188,21 +114,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0    10\n",
-      "1    11\n",
-      "2    12\n",
-      "3    13\n",
-      "dtype: int64\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(column)"
    ]
@@ -218,17 +132,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RangeIndex(start=0, stop=4, step=1)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(column.index)"
    ]
@@ -242,24 +148,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5    10\n",
-       "6    11\n",
-       "7    12\n",
-       "8    13\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "column.index = [5, 6, 7, 8] \n",
     "column"
@@ -295,19 +186,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Empty DataFrame\n",
-      "Columns: []\n",
-      "Index: []\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.DataFrame()\n",
     "print(df)"
@@ -322,23 +203,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NumPy Version: 1.22.4\n",
-      "   key  value\n",
-      "0    0     10\n",
-      "1    1     11\n",
-      "2    2     12\n",
-      "3    3     13\n",
-      "4    4     14\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np; print('NumPy Version:', np.__version__)\n",
     "\n",
@@ -360,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,22 +242,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   ids           timestamp\n",
-      "0    0 2018-10-07 12:00:00\n",
-      "1    1 2018-10-07 12:00:01\n",
-      "2    2 2018-10-07 12:00:02\n",
-      "3    3 2018-10-07 12:00:03\n",
-      "4    4 2018-10-07 12:00:04\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.DataFrame()\n",
     "df['ids'] = ids\n",
@@ -407,22 +261,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   id           timestamp\n",
-      "0   0 2018-10-07 12:00:00\n",
-      "1   1 2018-10-07 12:00:01\n",
-      "2   2 2018-10-07 12:00:02\n",
-      "3   3 2018-10-07 12:00:03\n",
-      "4   4 2018-10-07 12:00:04\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.DataFrame({'id': ids, 'timestamp': timestamps_np})\n",
     "print(df)"
@@ -439,29 +280,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Pandas Version: 1.4.4\n",
-      "     a    b\n",
-      "0    0  0.0\n",
-      "1    1  0.1\n",
-      "2    2  0.2\n",
-      "3    3  NaN\n",
-      "4    4  0.4\n",
-      "5    5  0.5\n",
-      "6    6  0.6\n",
-      "7    7  0.7\n",
-      "8    8  0.8\n",
-      "9    9  0.9\n",
-      "10  10  1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd; print('Pandas Version:', pd.__version__)\n",
     "\n",
@@ -480,28 +301,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     a     b\n",
-      "0    0   0.0\n",
-      "1    1   0.1\n",
-      "2    2   0.2\n",
-      "3    3  <NA>\n",
-      "4    4   0.4\n",
-      "5    5   0.5\n",
-      "6    6   0.6\n",
-      "7    7   0.7\n",
-      "8    8   0.8\n",
-      "9    9   0.9\n",
-      "10  10   1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.from_pandas(pandas_df)\n",
     "# df = cudf.DataFrame.from_pandas(pandas_df)  # alternative\n",
@@ -519,21 +321,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b   c\n",
-      "0  1  5   9\n",
-      "1  2  6  10\n",
-      "2  3  7  11\n",
-      "3  4  8  12\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "column1 = cudf.Series([1, 2, 3, 4])\n",
     "column2 = cudf.Series([5, 6, 7, 8])\n",
@@ -553,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,117 +352,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>99</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>98</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>97</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>4</td>\n",
-       "      <td>96</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>95</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>96</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>97</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>98</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>99</th>\n",
-       "      <td>99</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>100 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     a    b\n",
-       "0    0  100\n",
-       "1    1   99\n",
-       "2    2   98\n",
-       "3    3   97\n",
-       "4    4   96\n",
-       "..  ..  ...\n",
-       "95  95    5\n",
-       "96  96    4\n",
-       "97  97    3\n",
-       "98  98    2\n",
-       "99  99    1\n",
-       "\n",
-       "[100 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df"
    ]
@@ -686,30 +368,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     a    b\n",
-      "0    0  100\n",
-      "1    1   99\n",
-      "2    2   98\n",
-      "3    3   97\n",
-      "4    4   96\n",
-      "..  ..  ...\n",
-      "95  95    5\n",
-      "96  96    4\n",
-      "97  97    3\n",
-      "98  98    2\n",
-      "99  99    1\n",
-      "\n",
-      "[100 rows x 2 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df)"
    ]
@@ -723,22 +384,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a    b\n",
-      "0  0  100\n",
-      "1  1   99\n",
-      "2  2   98\n",
-      "3  3   97\n",
-      "4  4   96\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.head())"
    ]
@@ -754,17 +402,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Index(['a', 'b'], dtype='object')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.columns)"
    ]
@@ -778,17 +418,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Index(['c', 'd'], dtype='object')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.columns = ['c', 'd']\n",
     "print(df.columns)"
@@ -805,19 +437,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "c    int64\n",
-      "d    int64\n",
-      "dtype: object\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.dtypes)"
    ]
@@ -831,19 +453,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "c    float32\n",
-      "d      int32\n",
-      "dtype: object\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df['c'] = df['c'].astype(np.float32)\n",
     "df['d'] = df['d'].astype(np.int32)\n",
@@ -861,29 +473,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'cudf.core.series.Series'>\n",
-      "0      0.0\n",
-      "1      1.0\n",
-      "2      2.0\n",
-      "3      3.0\n",
-      "4      4.0\n",
-      "      ... \n",
-      "95    95.0\n",
-      "96    96.0\n",
-      "97    97.0\n",
-      "98    98.0\n",
-      "99    99.0\n",
-      "Name: c, Length: 100, dtype: float32\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(type(df['c']))\n",
     "print(df['c'])"
@@ -900,20 +492,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "RangeIndex(start=0, stop=100, step=1)"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.index"
    ]
@@ -927,18 +508,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     c   d\n",
-      "2  2.0  98\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df[df.index == 2])"
    ]
@@ -954,17 +526,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pandas_df = df.to_pandas()\n",
     "print(type(pandas_df))"
@@ -981,17 +545,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'numpy.ndarray'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "numpy_array = df.to_pandas().values\n",
     "print(type(numpy_array))"
@@ -1029,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,30 +601,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       c    d\n",
-      "0    0.0  100\n",
-      "1    1.0   99\n",
-      "2    2.0   98\n",
-      "3    3.0   97\n",
-      "4    4.0   96\n",
-      "..   ...  ...\n",
-      "95  95.0    5\n",
-      "96  96.0    4\n",
-      "97  97.0    3\n",
-      "98  98.0    2\n",
-      "99  99.0    1\n",
-      "\n",
-      "[100 rows x 2 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.read_csv('./dataset.csv')\n",
     "print(df)"
@@ -1104,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,22 +649,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     a      b\n",
-      "0  0.0  100.0\n",
-      "1  1.0   99.0\n",
-      "2  2.0   98.0\n",
-      "3  3.0   97.0\n",
-      "4  4.0   96.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df[0:5])"
    ]
@@ -1143,28 +665,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0      0.0\n",
-      "1      1.0\n",
-      "2      2.0\n",
-      "3      3.0\n",
-      "4      4.0\n",
-      "      ... \n",
-      "95    95.0\n",
-      "96    96.0\n",
-      "97    97.0\n",
-      "98    98.0\n",
-      "99    99.0\n",
-      "Name: a, Length: 100, dtype: float32\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df['a'])\n",
     "# print(df.a)  # alternative"
@@ -1179,30 +682,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       a      b\n",
-      "0    0.0  100.0\n",
-      "1    1.0   99.0\n",
-      "2    2.0   98.0\n",
-      "3    3.0   97.0\n",
-      "4    4.0   96.0\n",
-      "..   ...    ...\n",
-      "95  95.0    5.0\n",
-      "96  96.0    4.0\n",
-      "97  97.0    3.0\n",
-      "98  98.0    2.0\n",
-      "99  99.0    1.0\n",
-      "\n",
-      "[100 rows x 2 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df[['a', 'b']])"
    ]
@@ -1216,23 +698,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     a\n",
-      "0  0.0\n",
-      "1  1.0\n",
-      "2  2.0\n",
-      "3  3.0\n",
-      "4  4.0\n",
-      "5  5.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.loc[0:5, ['a']])\n",
     "# print(df.loc[0:5, ['a', 'b']])  # to select multiple columns, pass in multiple column names"
@@ -1249,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1260,30 +728,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       a      b      c      d\n",
-      "0    0.0  100.0  100.0  200.0\n",
-      "1    1.0   99.0  101.0  201.0\n",
-      "2    2.0   98.0  102.0  202.0\n",
-      "3    3.0   97.0  103.0  203.0\n",
-      "4    4.0   96.0  104.0  204.0\n",
-      "..   ...    ...    ...    ...\n",
-      "95  95.0    5.0  195.0  295.0\n",
-      "96  96.0    4.0  196.0  296.0\n",
-      "97  97.0    3.0  197.0  297.0\n",
-      "98  98.0    2.0  198.0  298.0\n",
-      "99  99.0    1.0  199.0  299.0\n",
-      "\n",
-      "[100 rows x 4 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df['d'] = np.arange(200, 300).astype(np.float32)\n",
     "\n",
@@ -1292,30 +739,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       a      b      c      d      e\n",
-      "0    0.0  100.0  100.0  200.0  300.0\n",
-      "1    1.0   99.0  101.0  201.0  301.0\n",
-      "2    2.0   98.0  102.0  202.0  302.0\n",
-      "3    3.0   97.0  103.0  203.0  303.0\n",
-      "4    4.0   96.0  104.0  204.0  304.0\n",
-      "..   ...    ...    ...    ...    ...\n",
-      "95  95.0    5.0  195.0  295.0  395.0\n",
-      "96  96.0    4.0  196.0  296.0  396.0\n",
-      "97  97.0    3.0  197.0  297.0  397.0\n",
-      "98  98.0    2.0  198.0  298.0  398.0\n",
-      "99  99.0    1.0  199.0  299.0  399.0\n",
-      "\n",
-      "[100 rows x 5 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = np.arange(300, 400).astype(np.float32)\n",
     "# df.add_column('e', data)\n",
@@ -1334,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1345,30 +771,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       a      b      c\n",
-      "0    0.0  100.0  100.0\n",
-      "1    1.0   99.0  101.0\n",
-      "2    2.0   98.0  102.0\n",
-      "3    3.0   97.0  103.0\n",
-      "4    4.0   96.0  104.0\n",
-      "..   ...    ...    ...\n",
-      "95  95.0    5.0  195.0\n",
-      "96  96.0    4.0  196.0\n",
-      "97  97.0    3.0  197.0\n",
-      "98  98.0    2.0  198.0\n",
-      "99  99.0    1.0  199.0\n",
-      "\n",
-      "[100 rows x 3 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# df.drop_column('a')\n",
     "df.drop(['a'], axis=1)\n",
@@ -1384,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1395,47 +800,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Original DataFrame:\n",
-      "       a      b      c\n",
-      "0    0.0  100.0  100.0\n",
-      "1    1.0   99.0  101.0\n",
-      "2    2.0   98.0  102.0\n",
-      "3    3.0   97.0  103.0\n",
-      "4    4.0   96.0  104.0\n",
-      "..   ...    ...    ...\n",
-      "95  95.0    5.0  195.0\n",
-      "96  96.0    4.0  196.0\n",
-      "97  97.0    3.0  197.0\n",
-      "98  98.0    2.0  198.0\n",
-      "99  99.0    1.0  199.0\n",
-      "\n",
-      "[100 rows x 3 columns]\n",
-      "-------------------------------------------------------------------------------\n",
-      "New DataFrame:\n",
-      "        b      c\n",
-      "0   100.0  100.0\n",
-      "1    99.0  101.0\n",
-      "2    98.0  102.0\n",
-      "3    97.0  103.0\n",
-      "4    96.0  104.0\n",
-      "..    ...    ...\n",
-      "95    5.0  195.0\n",
-      "96    4.0  196.0\n",
-      "97    3.0  197.0\n",
-      "98    2.0  198.0\n",
-      "99    1.0  199.0\n",
-      "\n",
-      "[100 rows x 2 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# new_df = df.drop('a')\n",
     "new_df = df.drop(['a'], axis=1)\n",
@@ -1455,47 +822,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Original DataFrame:\n",
-      "       a      b      c\n",
-      "0    0.0  100.0  100.0\n",
-      "1    1.0   99.0  101.0\n",
-      "2    2.0   98.0  102.0\n",
-      "3    3.0   97.0  103.0\n",
-      "4    4.0   96.0  104.0\n",
-      "..   ...    ...    ...\n",
-      "95  95.0    5.0  195.0\n",
-      "96  96.0    4.0  196.0\n",
-      "97  97.0    3.0  197.0\n",
-      "98  98.0    2.0  198.0\n",
-      "99  99.0    1.0  199.0\n",
-      "\n",
-      "[100 rows x 3 columns]\n",
-      "-------------------------------------------------------------------------------\n",
-      "New DataFrame:\n",
-      "        c\n",
-      "0   100.0\n",
-      "1   101.0\n",
-      "2   102.0\n",
-      "3   103.0\n",
-      "4   104.0\n",
-      "..    ...\n",
-      "95  195.0\n",
-      "96  196.0\n",
-      "97  197.0\n",
-      "98  198.0\n",
-      "99  199.0\n",
-      "\n",
-      "[100 rows x 1 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# new_df = df.drop(['a', 'b'])\n",
     "new_df = df.drop(['a', 'b'], axis=1)\n",
@@ -1518,28 +847,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       a     b     c\n",
-      "0      0   0.0   0.0\n",
-      "1   <NA>   0.1   0.1\n",
-      "2      2   0.2  <NA>\n",
-      "3      3  <NA>  <NA>\n",
-      "4      4   0.4   0.4\n",
-      "5      5   0.5   0.5\n",
-      "6      6   0.6  <NA>\n",
-      "7      7   0.7   0.7\n",
-      "8      8   0.8   0.8\n",
-      "9   <NA>   0.9   0.9\n",
-      "10    10   1.0   1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.DataFrame({'a': [0, None, 2, 3, 4, 5, 6, 7, 8, None, 10],\n",
     "                     'b': [0.0, 0.1, 0.2, None, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], \n",
@@ -1556,28 +866,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "       a     b      c\n",
-      "0      0   0.0    0.0\n",
-      "1   <NA>   0.1    0.1\n",
-      "2      2   0.2  999.0\n",
-      "3      3  <NA>  999.0\n",
-      "4      4   0.4    0.4\n",
-      "5      5   0.5    0.5\n",
-      "6      6   0.6  999.0\n",
-      "7      7   0.7    0.7\n",
-      "8      8   0.8    0.8\n",
-      "9   <NA>   0.9    0.9\n",
-      "10    10   1.0    1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df['c'] = df['c'].fillna(999)\n",
     "print(df)"
@@ -1585,28 +876,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     a    b      c\n",
-      "0    0  0.0    0.0\n",
-      "1   -1  0.1    0.1\n",
-      "2    2  0.2  999.0\n",
-      "3    3 -1.0  999.0\n",
-      "4    4  0.4    0.4\n",
-      "5    5  0.5    0.5\n",
-      "6    6  0.6  999.0\n",
-      "7    7  0.7    0.7\n",
-      "8    8  0.8    0.8\n",
-      "9   -1  0.9    0.9\n",
-      "10  10  1.0    1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "new_df = df.fillna(-1)\n",
     "print(new_df)"
@@ -1623,7 +895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1635,250 +907,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>c</th>\n",
-       "      <th>d</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>75</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>75</td>\n",
-       "      <td>25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>76</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>76</td>\n",
-       "      <td>24</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>77</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>77</td>\n",
-       "      <td>23</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>78</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>78</td>\n",
-       "      <td>22</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>79</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>79</td>\n",
-       "      <td>21</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>80</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>80</td>\n",
-       "      <td>20</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>81</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>81</td>\n",
-       "      <td>19</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>82</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>82</td>\n",
-       "      <td>18</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>83</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>83</td>\n",
-       "      <td>17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>84</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>84</td>\n",
-       "      <td>16</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>85</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>85</td>\n",
-       "      <td>15</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>86</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>86</td>\n",
-       "      <td>14</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>87</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>87</td>\n",
-       "      <td>13</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>88</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>88</td>\n",
-       "      <td>12</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>89</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>89</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>90</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>90</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>91</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>91</td>\n",
-       "      <td>9</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>92</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>92</td>\n",
-       "      <td>8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>93</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>93</td>\n",
-       "      <td>7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>94</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>94</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>95</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>96</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>97</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>98</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>99</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>99</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    a  b   c   d\n",
-       "75  3  0  75  25\n",
-       "76  3  1  76  24\n",
-       "77  3  1  77  23\n",
-       "78  3  1  78  22\n",
-       "79  3  1  79  21\n",
-       "80  3  1  80  20\n",
-       "81  3  1  81  19\n",
-       "82  3  1  82  18\n",
-       "83  3  0  83  17\n",
-       "84  3  0  84  16\n",
-       "85  3  0  85  15\n",
-       "86  3  0  86  14\n",
-       "87  3  1  87  13\n",
-       "88  3  0  88  12\n",
-       "89  3  1  89  11\n",
-       "90  3  0  90  10\n",
-       "91  3  1  91   9\n",
-       "92  3  1  92   8\n",
-       "93  3  0  93   7\n",
-       "94  3  1  94   6\n",
-       "95  3  0  95   5\n",
-       "96  3  0  96   4\n",
-       "97  3  0  97   3\n",
-       "98  3  1  98   2\n",
-       "99  3  0  99   1"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "mask = df['a'] == 3\n",
     "df[mask]"
@@ -1897,22 +928,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b  c    d\n",
-      "0  0  1  0  100\n",
-      "1  0  0  1   99\n",
-      "2  0  0  2   98\n",
-      "3  0  1  3   97\n",
-      "4  0  1  4   96\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.DataFrame({'a': np.repeat([0, 1, 2, 3], 25).astype(np.int32), \n",
     "                     'b': np.random.randint(2, size=100).astype(np.int32), \n",
@@ -1923,22 +941,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    a  b   c  d\n",
-      "99  3  1  99  1\n",
-      "98  3  0  98  2\n",
-      "97  3  1  97  3\n",
-      "96  3  1  96  4\n",
-      "95  3  1  95  5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.sort_values('d').head())"
    ]
@@ -1952,22 +957,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    a  b   c  d\n",
-      "99  3  1  99  1\n",
-      "98  3  0  98  2\n",
-      "97  3  1  97  3\n",
-      "96  3  1  96  4\n",
-      "95  3  1  95  5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.sort_values('c', ascending=False).head())"
    ]
@@ -1981,22 +973,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    a  b   c   d\n",
-      "1   0  0   1  99\n",
-      "2   0  0   2  98\n",
-      "8   0  0   8  92\n",
-      "9   0  0   9  91\n",
-      "13  0  0  13  87\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.sort_values(['a', 'b']).head())"
    ]
@@ -2010,31 +989,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sort with all columns specified descending:\n",
-      "    a  b   c   d\n",
-      "75  3  1  75  25\n",
-      "76  3  1  76  24\n",
-      "84  3  1  84  16\n",
-      "87  3  1  87  13\n",
-      "89  3  1  89  11\n",
-      "-------------------------------------------------------------------------------\n",
-      "Sort with both a descending and b ascending:\n",
-      "    a  b   c   d\n",
-      "77  3  0  77  23\n",
-      "78  3  0  78  22\n",
-      "79  3  0  79  21\n",
-      "80  3  0  80  20\n",
-      "81  3  0  81  19\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('Sort with all columns specified descending:')\n",
     "print(df.sort_values(['a', 'b'], ascending=False).head())\n",
@@ -2054,7 +1011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2066,41 +1023,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "150"
-      ]
-     },
-     "execution_count": 55,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df['a'].sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a     150\n",
-      "b      53\n",
-      "c    4950\n",
-      "d    5050\n",
-      "dtype: int64\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(df.sum())"
    ]
@@ -2116,7 +1050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2128,28 +1062,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0      10\n",
-      "1      11\n",
-      "2      12\n",
-      "3      13\n",
-      "4      14\n",
-      "     ... \n",
-      "95    105\n",
-      "96    106\n",
-      "97    107\n",
-      "98    108\n",
-      "99    109\n",
-      "Name: c, Length: 100, dtype: int64\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def add_ten_to_x(x):\n",
     "    return x + 10\n",
@@ -2168,7 +1083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2180,21 +1095,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0    25\n",
-      "2    25\n",
-      "3    25\n",
-      "1    25\n",
-      "Name: a, dtype: int32\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = df['a'].value_counts()\n",
     "print(result)"
@@ -2213,7 +1116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2229,141 +1132,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>c</th>\n",
-       "      <th>d</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>99</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>98</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>97</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>96</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>95</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>96</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>97</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>98</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>99</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>99</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>200 rows × 4 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    a  b   c    d\n",
-       "0   0  0   0  100\n",
-       "1   0  0   1   99\n",
-       "2   0  1   2   98\n",
-       "3   0  1   3   97\n",
-       "4   0  1   4   96\n",
-       ".. .. ..  ..  ...\n",
-       "95  3  1  95    5\n",
-       "96  3  0  96    4\n",
-       "97  3  1  97    3\n",
-       "98  3  0  98    2\n",
-       "99  3  0  99    1\n",
-       "\n",
-       "[200 rows x 4 columns]"
-      ]
-     },
-     "execution_count": 62,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.concat([df1, df2], axis=0)\n",
     "df"
@@ -2371,7 +1142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2387,189 +1158,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "      <th>b</th>\n",
-       "      <th>c</th>\n",
-       "      <th>d</th>\n",
-       "      <th>e</th>\n",
-       "      <th>f</th>\n",
-       "      <th>g</th>\n",
-       "      <th>h</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>100</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>99</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>99</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>98</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2</td>\n",
-       "      <td>98</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
-       "      <td>97</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>97</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>4</td>\n",
-       "      <td>96</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>96</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>95</td>\n",
-       "      <td>5</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>95</td>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>96</td>\n",
-       "      <td>4</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>96</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>97</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>97</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>98</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>98</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>99</th>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>99</td>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>99</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>100 rows × 8 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    a  b   c    d  e  f   g    h\n",
-       "0   0  0   0  100  0  1   0  100\n",
-       "1   0  0   1   99  0  0   1   99\n",
-       "2   0  1   2   98  0  0   2   98\n",
-       "3   0  0   3   97  0  1   3   97\n",
-       "4   0  0   4   96  0  1   4   96\n",
-       ".. .. ..  ..  ... .. ..  ..  ...\n",
-       "95  3  0  95    5  3  0  95    5\n",
-       "96  3  1  96    4  3  1  96    4\n",
-       "97  3  0  97    3  3  1  97    3\n",
-       "98  3  1  98    2  3  0  98    2\n",
-       "99  3  0  99    1  3  0  99    1\n",
-       "\n",
-       "[100 rows x 8 columns]"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.concat([df1, df2], axis=1)\n",
     "df"
@@ -2591,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2607,22 +1198,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b  c    d   e   f\n",
-      "0  0  1  0  100  17  83\n",
-      "1  0  1  0  100   3  97\n",
-      "2  0  1  0  100  19  81\n",
-      "3  0  1  0  100  20  80\n",
-      "4  0  1  1   99  17  83\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = df1.merge(df2)\n",
     "print(df.head())"
@@ -2630,22 +1208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b_x   c   d  b_y   e   f\n",
-      "0  1    0  48  52    0  25  75\n",
-      "1  1    0  48  52    0  26  74\n",
-      "2  1    0  48  52    1  32  68\n",
-      "3  1    0  48  52    1  33  67\n",
-      "4  1    1  49  51    0  25  75\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = df1.merge(df2, on=['a'])\n",
     "print(df.head())"
@@ -2653,22 +1218,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b   c   d   e    f\n",
-      "0  0  1  16  84   3   97\n",
-      "1  0  1  16  84  17   83\n",
-      "2  0  1  16  84   5   95\n",
-      "3  0  1  16  84   6   94\n",
-      "4  0  0  17  83   0  100\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = df1.merge(df2, on=['a', 'b'])\n",
     "print(df.head())"
@@ -2676,22 +1228,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b   c   d   e   f\n",
-      "0  1  0  32  68  25  75\n",
-      "1  1  0  32  68  48  52\n",
-      "2  1  0  32  68  34  66\n",
-      "3  1  0  32  68  49  51\n",
-      "4  1  0  33  67  25  75\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.merge(df1, df2)\n",
     "print(df.head())"
@@ -2699,22 +1238,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b_x   c   d  b_y   e   f\n",
-      "0  1    0  48  52    0  25  75\n",
-      "1  1    0  48  52    0  26  74\n",
-      "2  1    0  48  52    1  32  68\n",
-      "3  1    0  48  52    1  33  67\n",
-      "4  1    1  49  51    0  25  75\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.merge(df1, df2, on=['a'])\n",
     "print(df.head())"
@@ -2722,22 +1248,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b   c   d   e   f\n",
-      "0  3  0  80  20  81  19\n",
-      "1  3  0  80  20  98   2\n",
-      "2  3  0  80  20  83  17\n",
-      "3  3  0  80  20  86  14\n",
-      "4  3  0  81  19  81  19\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.merge(df1, df2, on=['a', 'b'])\n",
     "print(df.head())"
@@ -2758,22 +1271,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b  c    d\n",
-      "0  0  0  0  100\n",
-      "1  0  0  1   99\n",
-      "2  0  1  2   98\n",
-      "3  0  1  3   97\n",
-      "4  0  0  4   96\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = cudf.DataFrame({'a': np.repeat([0, 1, 2, 3], 25).astype(np.int32), \n",
     "                     'b': np.random.randint(2, size=100).astype(np.int32), \n",
@@ -2784,20 +1284,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<cudf.core.groupby.groupby.DataFrameGroupBy at 0x7f091fc47610>"
-      ]
-     },
-     "execution_count": 73,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "grouped_df = df.groupby('a')\n",
     "grouped_df"
@@ -2805,22 +1294,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    b     c     d\n",
-      "a                \n",
-      "0  15   300  2200\n",
-      "2  10  1550   950\n",
-      "3  14  2175   325\n",
-      "1   4   925  1575\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "aggregation = grouped_df.sum()\n",
     "print(aggregation)"
@@ -2828,26 +1304,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "        c     d\n",
-      "a b            \n",
-      "1 1   151   249\n",
-      "  0   774  1326\n",
-      "0 0   132   868\n",
-      "2 1   656   344\n",
-      "0 1   168  1332\n",
-      "2 0   894   606\n",
-      "3 1  1240   160\n",
-      "  0   935   165\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "aggregation = df.groupby(['a', 'b']).sum().to_pandas()\n",
     "print(aggregation)"
@@ -2866,22 +1325,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   a  b    c\n",
-      "0  0  0  100\n",
-      "1  0  1   99\n",
-      "2  0  2   98\n",
-      "3  0  3   97\n",
-      "4  0  4   96\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "categories = [0, 1, 2, 3]\n",
     "df = cudf.DataFrame({'a': np.repeat(categories, 25).astype(np.int32), \n",
@@ -2892,28 +1338,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   b    c  a__0  a__1  a__2  a__3\n",
-      "0  0  100     1     0     0     0\n",
-      "1  1   99     1     0     0     0\n",
-      "2  2   98     1     0     0     0\n",
-      "3  3   97     1     0     0     0\n",
-      "4  4   96     1     0     0     0\n",
-      "     b  c  a__0  a__1  a__2  a__3\n",
-      "95  95  5     0     0     0     1\n",
-      "96  96  4     0     0     0     1\n",
-      "97  97  3     0     0     0     1\n",
-      "98  98  2     0     0     0     1\n",
-      "99  99  1     0     0     0     1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = cudf.get_dummies(df, columns='a', prefix='a_', cats=categories)\n",
     "print(result.head())\n",
@@ -2922,28 +1349,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   b    c  a__0  a__1  a__2  a__3\n",
-      "0  0  100     1     0     0     0\n",
-      "1  1   99     1     0     0     0\n",
-      "2  2   98     1     0     0     0\n",
-      "3  3   97     1     0     0     0\n",
-      "4  4   96     1     0     0     0\n",
-      "     b  c  a__0  a__1  a__2  a__3\n",
-      "95  95  5     0     0     0     1\n",
-      "96  96  4     0     0     0     1\n",
-      "97  97  3     0     0     0     1\n",
-      "98  98  2     0     0     0     1\n",
-      "99  99  1     0     0     0     1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "result = cudf.get_dummies(df, columns='a', prefix='a_', cats=[0, 1, 2])\n",
     "print(result.head())\n",

--- a/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
+++ b/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
@@ -49,16 +49,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Wed Mar 24 23:39:15 2021       \n",
+      "Mon Sep 19 17:00:40 2022       \n",
       "+-----------------------------------------------------------------------------+\n",
-      "| NVIDIA-SMI 450.80.02    Driver Version: 450.80.02    CUDA Version: 11.0     |\n",
+      "| NVIDIA-SMI 495.29.05    Driver Version: 495.29.05    CUDA Version: 11.5     |\n",
       "|-------------------------------+----------------------+----------------------+\n",
       "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
       "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
       "|                               |                      |               MIG M. |\n",
       "|===============================+======================+======================|\n",
-      "|   0  Tesla T4            On   | 00000000:00:1E.0 Off |                    0 |\n",
-      "| N/A   42C    P0    26W /  70W |    864MiB / 15109MiB |      0%      Default |\n",
+      "|   0  Quadro RTX 8000     Off  | 00000000:15:00.0 Off |                  Off |\n",
+      "| 33%   29C    P8    11W / 260W |    508MiB / 48601MiB |      0%      Default |\n",
+      "|                               |                      |                  N/A |\n",
+      "+-------------------------------+----------------------+----------------------+\n",
+      "|   1  Quadro RTX 8000     Off  | 00000000:2D:00.0  On |                  Off |\n",
+      "| 33%   38C    P8    35W / 260W |    549MiB / 48598MiB |     44%      Default |\n",
       "|                               |                      |                  N/A |\n",
       "+-------------------------------+----------------------+----------------------+\n",
       "                                                                               \n",
@@ -67,6 +71,15 @@
       "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
       "|        ID   ID                                                   Usage      |\n",
       "|=============================================================================|\n",
+      "|    0   N/A  N/A      1021      G   /usr/lib/xorg/Xorg                  4MiB |\n",
+      "|    0   N/A  N/A      2354      G   /usr/lib/xorg/Xorg                  4MiB |\n",
+      "|    0   N/A  N/A      6919      C   ...s/rapids-22.08/bin/python      495MiB |\n",
+      "|    1   N/A  N/A      1021      G   /usr/lib/xorg/Xorg                 39MiB |\n",
+      "|    1   N/A  N/A      2354      G   /usr/lib/xorg/Xorg                155MiB |\n",
+      "|    1   N/A  N/A      2479      G   /usr/bin/gnome-shell               41MiB |\n",
+      "|    1   N/A  N/A      2944      G   /usr/lib/firefox/firefox          168MiB |\n",
+      "|    1   N/A  N/A      5957      G   ...veSuggestionsOnlyOnDemand       92MiB |\n",
+      "|    1   N/A  N/A     19040      G   ...RendererForSitePerProcess       37MiB |\n",
       "+-----------------------------------------------------------------------------+\n"
      ]
     }
@@ -91,7 +104,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/bin/sh: 1: nvcc: not found\n"
+      "nvcc: NVIDIA (R) Cuda compiler driver\n",
+      "Copyright (c) 2005-2021 NVIDIA Corporation\n",
+      "Built on Mon_Sep_13_19:13:29_PDT_2021\n",
+      "Cuda compilation tools, release 11.5, V11.5.50\n",
+      "Build cuda_11.5.r11.5/compiler.30411180_0\n"
      ]
     }
    ],
@@ -118,7 +135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cuDF Version: 0.17.0a+382.gbd321d1e93\n"
+      "cuDF Version: 22.10.00a+280.ge5636c83c3\n"
      ]
     }
    ],
@@ -229,15 +246,18 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5    10\n",
-      "6    11\n",
-      "7    12\n",
-      "8    13\n",
-      "dtype: int64\n"
-     ]
+     "data": {
+      "text/plain": [
+       "5    10\n",
+       "6    11\n",
+       "7    12\n",
+       "8    13\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -309,7 +329,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NumPy Version: 1.19.4\n",
+      "NumPy Version: 1.22.4\n",
       "   key  value\n",
       "0    0     10\n",
       "1    1     11\n",
@@ -426,7 +446,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pandas Version: 1.1.4\n",
+      "Pandas Version: 1.4.4\n",
       "     a    b\n",
       "0    0  0.0\n",
       "1    1  0.1\n",
@@ -1656,14 +1676,14 @@
        "    <tr>\n",
        "      <th>76</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>76</td>\n",
        "      <td>24</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>77</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>77</td>\n",
        "      <td>23</td>\n",
        "    </tr>\n",
@@ -1677,21 +1697,21 @@
        "    <tr>\n",
        "      <th>79</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>79</td>\n",
        "      <td>21</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>80</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>80</td>\n",
        "      <td>20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>81</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>81</td>\n",
        "      <td>19</td>\n",
        "    </tr>\n",
@@ -1705,7 +1725,7 @@
        "    <tr>\n",
        "      <th>83</th>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>83</td>\n",
        "      <td>17</td>\n",
        "    </tr>\n",
@@ -1726,7 +1746,7 @@
        "    <tr>\n",
        "      <th>86</th>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>86</td>\n",
        "      <td>14</td>\n",
        "    </tr>\n",
@@ -1747,7 +1767,7 @@
        "    <tr>\n",
        "      <th>89</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>89</td>\n",
        "      <td>11</td>\n",
        "    </tr>\n",
@@ -1761,7 +1781,7 @@
        "    <tr>\n",
        "      <th>91</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>91</td>\n",
        "      <td>9</td>\n",
        "    </tr>\n",
@@ -1789,7 +1809,7 @@
        "    <tr>\n",
        "      <th>95</th>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>95</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
@@ -1828,26 +1848,26 @@
       "text/plain": [
        "    a  b   c   d\n",
        "75  3  0  75  25\n",
-       "76  3  0  76  24\n",
-       "77  3  0  77  23\n",
+       "76  3  1  76  24\n",
+       "77  3  1  77  23\n",
        "78  3  1  78  22\n",
-       "79  3  0  79  21\n",
-       "80  3  0  80  20\n",
-       "81  3  0  81  19\n",
+       "79  3  1  79  21\n",
+       "80  3  1  80  20\n",
+       "81  3  1  81  19\n",
        "82  3  1  82  18\n",
-       "83  3  1  83  17\n",
+       "83  3  0  83  17\n",
        "84  3  0  84  16\n",
        "85  3  0  85  15\n",
-       "86  3  1  86  14\n",
+       "86  3  0  86  14\n",
        "87  3  1  87  13\n",
        "88  3  0  88  12\n",
-       "89  3  0  89  11\n",
+       "89  3  1  89  11\n",
        "90  3  0  90  10\n",
-       "91  3  0  91   9\n",
+       "91  3  1  91   9\n",
        "92  3  1  92   8\n",
        "93  3  0  93   7\n",
        "94  3  1  94   6\n",
-       "95  3  1  95   5\n",
+       "95  3  0  95   5\n",
        "96  3  0  96   4\n",
        "97  3  0  97   3\n",
        "98  3  1  98   2\n",
@@ -1885,11 +1905,11 @@
      "output_type": "stream",
      "text": [
       "   a  b  c    d\n",
-      "0  0  0  0  100\n",
+      "0  0  1  0  100\n",
       "1  0  0  1   99\n",
-      "2  0  1  2   98\n",
-      "3  0  0  3   97\n",
-      "4  0  0  4   96\n"
+      "2  0  0  2   98\n",
+      "3  0  1  3   97\n",
+      "4  0  1  4   96\n"
      ]
     }
    ],
@@ -1913,8 +1933,8 @@
       "    a  b   c  d\n",
       "99  3  1  99  1\n",
       "98  3  0  98  2\n",
-      "97  3  0  97  3\n",
-      "96  3  0  96  4\n",
+      "97  3  1  97  3\n",
+      "96  3  1  96  4\n",
       "95  3  1  95  5\n"
      ]
     }
@@ -1942,8 +1962,8 @@
       "    a  b   c  d\n",
       "99  3  1  99  1\n",
       "98  3  0  98  2\n",
-      "97  3  0  97  3\n",
-      "96  3  0  96  4\n",
+      "97  3  1  97  3\n",
+      "96  3  1  96  4\n",
       "95  3  1  95  5\n"
      ]
     }
@@ -1968,12 +1988,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b  c    d\n",
-      "0  0  0  0  100\n",
-      "1  0  0  1   99\n",
-      "3  0  0  3   97\n",
-      "4  0  0  4   96\n",
-      "5  0  0  5   95\n"
+      "    a  b   c   d\n",
+      "1   0  0   1  99\n",
+      "2   0  0   2  98\n",
+      "8   0  0   8  92\n",
+      "9   0  0   9  91\n",
+      "13  0  0  13  87\n"
      ]
     }
    ],
@@ -2000,26 +2020,18 @@
       "Sort with all columns specified descending:\n",
       "    a  b   c   d\n",
       "75  3  1  75  25\n",
-      "78  3  1  78  22\n",
-      "81  3  1  81  19\n",
-      "83  3  1  83  17\n",
-      "85  3  1  85  15\n",
+      "76  3  1  76  24\n",
+      "84  3  1  84  16\n",
+      "87  3  1  87  13\n",
+      "89  3  1  89  11\n",
       "-------------------------------------------------------------------------------\n",
       "Sort with both a descending and b ascending:\n",
       "    a  b   c   d\n",
-      "76  3  0  76  24\n",
       "77  3  0  77  23\n",
+      "78  3  0  78  22\n",
       "79  3  0  79  21\n",
       "80  3  0  80  20\n",
-      "82  3  0  82  18\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/rapids/lib/python3.7/site-packages/cudf/core/frame.py:2561: UserWarning: When using a sequence of booleans for `ascending`, `na_position` flag is not yet supported and defaults to treating nulls as greater than all numbers\n",
-      "  \"When using a sequence of booleans for `ascending`, \"\n"
+      "81  3  0  81  19\n"
      ]
     }
    ],
@@ -2082,10 +2094,10 @@
      "output_type": "stream",
      "text": [
       "a     150\n",
-      "b      48\n",
+      "b      53\n",
       "c    4950\n",
       "d    5050\n",
-      "dtype: int32\n"
+      "dtype: int64\n"
      ]
     }
    ],
@@ -2097,9 +2109,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Applymap Operations\n",
+    "#### Series Apply Operations\n",
     "\n",
-    "While cuDF allows us to define new columns in interesting ways, we often want to work with more complex functions. We can define a function and use the `applymap` method to apply this function to each value in a column in element-wise fashion. While the below example is simple, it can be very easily extended to more complex workflows."
+    "While cuDF allows us to define new columns in interesting ways, we often want to work with more complex functions. We can define a function and use the `apply` method to apply this function to each value in a column in element-wise fashion. While the below example is simple, it can be very easily extended to more complex workflows."
    ]
   },
   {
@@ -2142,7 +2154,7 @@
     "def add_ten_to_x(x):\n",
     "    return x + 10\n",
     "\n",
-    "print(df['c'].applymap(add_ten_to_x))"
+    "print(df['c'].apply(add_ten_to_x))"
    ]
   },
   {
@@ -2176,9 +2188,9 @@
      "output_type": "stream",
      "text": [
       "0    25\n",
-      "1    25\n",
       "2    25\n",
       "3    25\n",
+      "1    25\n",
       "Name: a, dtype: int32\n"
      ]
     }
@@ -2258,7 +2270,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>99</td>\n",
        "    </tr>\n",
@@ -2272,7 +2284,7 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>3</td>\n",
        "      <td>97</td>\n",
        "    </tr>\n",
@@ -2293,14 +2305,14 @@
        "    <tr>\n",
        "      <th>95</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>95</td>\n",
        "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>96</th>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>96</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
@@ -2333,13 +2345,13 @@
       "text/plain": [
        "    a  b   c    d\n",
        "0   0  0   0  100\n",
-       "1   0  1   1   99\n",
+       "1   0  0   1   99\n",
        "2   0  1   2   98\n",
-       "3   0  0   3   97\n",
+       "3   0  1   3   97\n",
        "4   0  1   4   96\n",
        ".. .. ..  ..  ...\n",
-       "95  3  0  95    5\n",
-       "96  3  1  96    4\n",
+       "95  3  1  95    5\n",
+       "96  3  0  96    4\n",
        "97  3  1  97    3\n",
        "98  3  0  98    2\n",
        "99  3  0  99    1\n",
@@ -2413,7 +2425,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>100</td>\n",
        "      <td>0</td>\n",
@@ -2435,7 +2447,7 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>98</td>\n",
        "      <td>0</td>\n",
@@ -2446,18 +2458,18 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>3</td>\n",
        "      <td>97</td>\n",
        "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>3</td>\n",
        "      <td>97</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>4</td>\n",
        "      <td>96</td>\n",
        "      <td>0</td>\n",
@@ -2490,22 +2502,22 @@
        "    <tr>\n",
        "      <th>96</th>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>96</td>\n",
        "      <td>4</td>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>96</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>97</th>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>97</td>\n",
        "      <td>3</td>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
        "      <td>97</td>\n",
        "      <td>3</td>\n",
        "    </tr>\n",
@@ -2516,7 +2528,7 @@
        "      <td>98</td>\n",
        "      <td>2</td>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>98</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
@@ -2527,7 +2539,7 @@
        "      <td>99</td>\n",
        "      <td>1</td>\n",
        "      <td>3</td>\n",
-       "      <td>1</td>\n",
+       "      <td>0</td>\n",
        "      <td>99</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
@@ -2538,17 +2550,17 @@
       ],
       "text/plain": [
        "    a  b   c    d  e  f   g    h\n",
-       "0   0  1   0  100  0  1   0  100\n",
+       "0   0  0   0  100  0  1   0  100\n",
        "1   0  0   1   99  0  0   1   99\n",
-       "2   0  0   2   98  0  0   2   98\n",
-       "3   0  1   3   97  0  0   3   97\n",
-       "4   0  1   4   96  0  1   4   96\n",
+       "2   0  1   2   98  0  0   2   98\n",
+       "3   0  0   3   97  0  1   3   97\n",
+       "4   0  0   4   96  0  1   4   96\n",
        ".. .. ..  ..  ... .. ..  ..  ...\n",
        "95  3  0  95    5  3  0  95    5\n",
-       "96  3  0  96    4  3  0  96    4\n",
-       "97  3  1  97    3  3  0  97    3\n",
-       "98  3  1  98    2  3  1  98    2\n",
-       "99  3  0  99    1  3  1  99    1\n",
+       "96  3  1  96    4  3  1  96    4\n",
+       "97  3  0  97    3  3  1  97    3\n",
+       "98  3  1  98    2  3  0  98    2\n",
+       "99  3  0  99    1  3  0  99    1\n",
        "\n",
        "[100 rows x 8 columns]"
       ]
@@ -2602,12 +2614,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b  c    d  e    f\n",
-      "0  0  1  0  100  1   99\n",
-      "1  0  1  1   99  1   99\n",
-      "2  0  1  2   98  1   99\n",
-      "3  0  0  3   97  0  100\n",
-      "4  0  0  4   96  0  100\n"
+      "   a  b  c    d   e   f\n",
+      "0  0  1  0  100  17  83\n",
+      "1  0  1  0  100   3  97\n",
+      "2  0  1  0  100  19  81\n",
+      "3  0  1  0  100  20  80\n",
+      "4  0  1  1   99  17  83\n"
      ]
     }
    ],
@@ -2625,12 +2637,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b_x  c    d  b_y  e    f\n",
-      "0  0    1  0  100    0  0  100\n",
-      "1  0    1  1   99    0  0  100\n",
-      "2  0    1  2   98    0  0  100\n",
-      "3  0    0  3   97    0  0  100\n",
-      "4  0    0  4   96    0  0  100\n"
+      "   a  b_x   c   d  b_y   e   f\n",
+      "0  1    0  48  52    0  25  75\n",
+      "1  1    0  48  52    0  26  74\n",
+      "2  1    0  48  52    1  32  68\n",
+      "3  1    0  48  52    1  33  67\n",
+      "4  1    1  49  51    0  25  75\n"
      ]
     }
    ],
@@ -2648,12 +2660,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b  c    d  e    f\n",
-      "0  0  1  0  100  1   99\n",
-      "1  0  1  1   99  1   99\n",
-      "2  0  1  2   98  1   99\n",
-      "3  0  0  3   97  0  100\n",
-      "4  0  0  4   96  0  100\n"
+      "   a  b   c   d   e    f\n",
+      "0  0  1  16  84   3   97\n",
+      "1  0  1  16  84  17   83\n",
+      "2  0  1  16  84   5   95\n",
+      "3  0  1  16  84   6   94\n",
+      "4  0  0  17  83   0  100\n"
      ]
     }
    ],
@@ -2671,12 +2683,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b  c    d  e    f\n",
-      "0  0  1  0  100  1   99\n",
-      "1  0  1  1   99  1   99\n",
-      "2  0  1  2   98  1   99\n",
-      "3  0  0  3   97  0  100\n",
-      "4  0  0  4   96  0  100\n"
+      "   a  b   c   d   e   f\n",
+      "0  1  0  32  68  25  75\n",
+      "1  1  0  32  68  48  52\n",
+      "2  1  0  32  68  34  66\n",
+      "3  1  0  32  68  49  51\n",
+      "4  1  0  33  67  25  75\n"
      ]
     }
    ],
@@ -2694,12 +2706,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b_x  c    d  b_y  e    f\n",
-      "0  0    1  0  100    0  0  100\n",
-      "1  0    1  1   99    0  0  100\n",
-      "2  0    1  2   98    0  0  100\n",
-      "3  0    0  3   97    0  0  100\n",
-      "4  0    0  4   96    0  0  100\n"
+      "   a  b_x   c   d  b_y   e   f\n",
+      "0  1    0  48  52    0  25  75\n",
+      "1  1    0  48  52    0  26  74\n",
+      "2  1    0  48  52    1  32  68\n",
+      "3  1    0  48  52    1  33  67\n",
+      "4  1    1  49  51    0  25  75\n"
      ]
     }
    ],
@@ -2717,12 +2729,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   a  b  c    d  e    f\n",
-      "0  0  1  0  100  1   99\n",
-      "1  0  1  1   99  1   99\n",
-      "2  0  1  2   98  1   99\n",
-      "3  0  0  3   97  0  100\n",
-      "4  0  0  4   96  0  100\n"
+      "   a  b   c   d   e   f\n",
+      "0  3  0  80  20  81  19\n",
+      "1  3  0  80  20  98   2\n",
+      "2  3  0  80  20  83  17\n",
+      "3  3  0  80  20  86  14\n",
+      "4  3  0  81  19  81  19\n"
      ]
     }
    ],
@@ -2754,11 +2766,11 @@
      "output_type": "stream",
      "text": [
       "   a  b  c    d\n",
-      "0  0  1  0  100\n",
+      "0  0  0  0  100\n",
       "1  0  0  1   99\n",
-      "2  0  0  2   98\n",
+      "2  0  1  2   98\n",
       "3  0  1  3   97\n",
-      "4  0  1  4   96\n"
+      "4  0  0  4   96\n"
      ]
     }
    ],
@@ -2778,7 +2790,7 @@
     {
      "data": {
       "text/plain": [
-       "<cudf.core.groupby.groupby.DataFrameGroupBy at 0x7f65d4dd8690>"
+       "<cudf.core.groupby.groupby.DataFrameGroupBy at 0x7f091fc47610>"
       ]
      },
      "execution_count": 73,
@@ -2802,10 +2814,10 @@
      "text": [
       "    b     c     d\n",
       "a                \n",
-      "0   8   300  2200\n",
-      "1  11   925  1575\n",
-      "2   9  1550   950\n",
-      "3  11  2175   325\n"
+      "0  15   300  2200\n",
+      "2  10  1550   950\n",
+      "3  14  2175   325\n",
+      "1   4   925  1575\n"
      ]
     }
    ],
@@ -2825,14 +2837,14 @@
      "text": [
       "        c     d\n",
       "a b            \n",
-      "0 0   209  1491\n",
-      "  1    91   709\n",
-      "1 0   519   881\n",
-      "  1   406   694\n",
-      "2 0   997   603\n",
-      "  1   553   347\n",
-      "3 0  1196   204\n",
-      "  1   979   121\n"
+      "1 1   151   249\n",
+      "  0   774  1326\n",
+      "0 0   132   868\n",
+      "2 1   656   344\n",
+      "0 1   168  1332\n",
+      "2 0   894   606\n",
+      "3 1  1240   160\n",
+      "  0   935   165\n"
      ]
     }
    ],
@@ -2854,7 +2866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -2880,7 +2892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -2910,7 +2922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -2960,7 +2972,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2974,7 +2986,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
+++ b/getting_started_materials/intro_tutorials_and_guides/02_Introduction_to_cuDF.ipynb
@@ -42,9 +42,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mon Sep 19 17:07:42 2022       \n",
+      "+-----------------------------------------------------------------------------+\n",
+      "| NVIDIA-SMI 495.29.05    Driver Version: 495.29.05    CUDA Version: 11.5     |\n",
+      "|-------------------------------+----------------------+----------------------+\n",
+      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
+      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
+      "|                               |                      |               MIG M. |\n",
+      "|===============================+======================+======================|\n",
+      "|   0  Quadro RTX 8000     Off  | 00000000:15:00.0 Off |                  Off |\n",
+      "| 33%   31C    P8    11W / 260W |   1001MiB / 48601MiB |      0%      Default |\n",
+      "|                               |                      |                  N/A |\n",
+      "+-------------------------------+----------------------+----------------------+\n",
+      "|   1  Quadro RTX 8000     Off  | 00000000:2D:00.0  On |                  Off |\n",
+      "| 33%   38C    P8    35W / 260W |    544MiB / 48598MiB |     18%      Default |\n",
+      "|                               |                      |                  N/A |\n",
+      "+-------------------------------+----------------------+----------------------+\n",
+      "                                                                               \n",
+      "+-----------------------------------------------------------------------------+\n",
+      "| Processes:                                                                  |\n",
+      "|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |\n",
+      "|        ID   ID                                                   Usage      |\n",
+      "|=============================================================================|\n",
+      "|    0   N/A  N/A      1021      G   /usr/lib/xorg/Xorg                  4MiB |\n",
+      "|    0   N/A  N/A      2354      G   /usr/lib/xorg/Xorg                  4MiB |\n",
+      "|    0   N/A  N/A      6919      C   ...s/rapids-22.08/bin/python      495MiB |\n",
+      "|    0   N/A  N/A     21657      C   ...s/rapids-22.08/bin/python      493MiB |\n",
+      "|    1   N/A  N/A      1021      G   /usr/lib/xorg/Xorg                 39MiB |\n",
+      "|    1   N/A  N/A      2354      G   /usr/lib/xorg/Xorg                155MiB |\n",
+      "|    1   N/A  N/A      2479      G   /usr/bin/gnome-shell               41MiB |\n",
+      "|    1   N/A  N/A      2944      G   /usr/lib/firefox/firefox          160MiB |\n",
+      "|    1   N/A  N/A      5957      G   ...veSuggestionsOnlyOnDemand       96MiB |\n",
+      "|    1   N/A  N/A     19040      G   ...RendererForSitePerProcess       37MiB |\n",
+      "+-----------------------------------------------------------------------------+\n"
+     ]
+    }
+   ],
    "source": [
     "!nvidia-smi"
    ]
@@ -58,9 +98,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nvcc: NVIDIA (R) Cuda compiler driver\n",
+      "Copyright (c) 2005-2021 NVIDIA Corporation\n",
+      "Built on Mon_Sep_13_19:13:29_PDT_2021\n",
+      "Cuda compilation tools, release 11.5, V11.5.50\n",
+      "Build cuda_11.5.r11.5/compiler.30411180_0\n"
+     ]
+    }
+   ],
    "source": [
     "!nvcc --version"
    ]
@@ -77,9 +129,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cuDF Version: 22.10.00a+280.ge5636c83c3\n"
+     ]
+    }
+   ],
    "source": [
     "import cudf; print('cuDF Version:', cudf.__version__)"
    ]
@@ -95,9 +155,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    10\n",
+       "1    11\n",
+       "2    12\n",
+       "3    13\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "column = cudf.Series([10, 11, 12, 13])\n",
     "column"
@@ -114,9 +189,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0    10\n",
+      "1    11\n",
+      "2    12\n",
+      "3    13\n",
+      "dtype: int64\n"
+     ]
+    }
+   ],
    "source": [
     "print(column)"
    ]
@@ -132,9 +219,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RangeIndex(start=0, stop=4, step=1)\n"
+     ]
+    }
+   ],
    "source": [
     "print(column.index)"
    ]
@@ -148,9 +243,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5    10\n",
+       "6    11\n",
+       "7    12\n",
+       "8    13\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "column.index = [5, 6, 7, 8] \n",
     "column"
@@ -186,9 +296,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Empty DataFrame\n",
+      "Columns: []\n",
+      "Index: []\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.DataFrame()\n",
     "print(df)"
@@ -203,9 +323,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NumPy Version: 1.22.4\n",
+      "   key  value\n",
+      "0    0     10\n",
+      "1    1     11\n",
+      "2    2     12\n",
+      "3    3     13\n",
+      "4    4     14\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np; print('NumPy Version:', np.__version__)\n",
     "\n",
@@ -227,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,9 +376,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ids           timestamp\n",
+      "0    0 2018-10-07 12:00:00\n",
+      "1    1 2018-10-07 12:00:01\n",
+      "2    2 2018-10-07 12:00:02\n",
+      "3    3 2018-10-07 12:00:03\n",
+      "4    4 2018-10-07 12:00:04\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.DataFrame()\n",
     "df['ids'] = ids\n",
@@ -261,9 +408,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   id           timestamp\n",
+      "0   0 2018-10-07 12:00:00\n",
+      "1   1 2018-10-07 12:00:01\n",
+      "2   2 2018-10-07 12:00:02\n",
+      "3   3 2018-10-07 12:00:03\n",
+      "4   4 2018-10-07 12:00:04\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.DataFrame({'id': ids, 'timestamp': timestamps_np})\n",
     "print(df)"
@@ -280,9 +440,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pandas Version: 1.4.4\n",
+      "     a    b\n",
+      "0    0  0.0\n",
+      "1    1  0.1\n",
+      "2    2  0.2\n",
+      "3    3  NaN\n",
+      "4    4  0.4\n",
+      "5    5  0.5\n",
+      "6    6  0.6\n",
+      "7    7  0.7\n",
+      "8    8  0.8\n",
+      "9    9  0.9\n",
+      "10  10  1.0\n"
+     ]
+    }
+   ],
    "source": [
     "import pandas as pd; print('Pandas Version:', pd.__version__)\n",
     "\n",
@@ -301,9 +481,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     a     b\n",
+      "0    0   0.0\n",
+      "1    1   0.1\n",
+      "2    2   0.2\n",
+      "3    3  <NA>\n",
+      "4    4   0.4\n",
+      "5    5   0.5\n",
+      "6    6   0.6\n",
+      "7    7   0.7\n",
+      "8    8   0.8\n",
+      "9    9   0.9\n",
+      "10  10   1.0\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.from_pandas(pandas_df)\n",
     "# df = cudf.DataFrame.from_pandas(pandas_df)  # alternative\n",
@@ -321,9 +520,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b   c\n",
+      "0  1  5   9\n",
+      "1  2  6  10\n",
+      "2  3  7  11\n",
+      "3  4  8  12\n"
+     ]
+    }
+   ],
    "source": [
     "column1 = cudf.Series([1, 2, 3, 4])\n",
     "column2 = cudf.Series([5, 6, 7, 8])\n",
@@ -343,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,9 +563,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>98</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>96</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>95</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>96</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>97</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>98</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>99</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     a    b\n",
+       "0    0  100\n",
+       "1    1   99\n",
+       "2    2   98\n",
+       "3    3   97\n",
+       "4    4   96\n",
+       "..  ..  ...\n",
+       "95  95    5\n",
+       "96  96    4\n",
+       "97  97    3\n",
+       "98  98    2\n",
+       "99  99    1\n",
+       "\n",
+       "[100 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df"
    ]
@@ -368,9 +687,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     a    b\n",
+      "0    0  100\n",
+      "1    1   99\n",
+      "2    2   98\n",
+      "3    3   97\n",
+      "4    4   96\n",
+      "..  ..  ...\n",
+      "95  95    5\n",
+      "96  96    4\n",
+      "97  97    3\n",
+      "98  98    2\n",
+      "99  99    1\n",
+      "\n",
+      "[100 rows x 2 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "print(df)"
    ]
@@ -384,9 +724,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a    b\n",
+      "0  0  100\n",
+      "1  1   99\n",
+      "2  2   98\n",
+      "3  3   97\n",
+      "4  4   96\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.head())"
    ]
@@ -402,9 +755,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['a', 'b'], dtype='object')\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.columns)"
    ]
@@ -418,9 +779,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['c', 'd'], dtype='object')\n"
+     ]
+    }
+   ],
    "source": [
     "df.columns = ['c', 'd']\n",
     "print(df.columns)"
@@ -437,9 +806,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c    int64\n",
+      "d    int64\n",
+      "dtype: object\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.dtypes)"
    ]
@@ -453,9 +832,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c    float32\n",
+      "d      int32\n",
+      "dtype: object\n"
+     ]
+    }
+   ],
    "source": [
     "df['c'] = df['c'].astype(np.float32)\n",
     "df['d'] = df['d'].astype(np.int32)\n",
@@ -473,9 +862,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'cudf.core.series.Series'>\n",
+      "0      0.0\n",
+      "1      1.0\n",
+      "2      2.0\n",
+      "3      3.0\n",
+      "4      4.0\n",
+      "      ... \n",
+      "95    95.0\n",
+      "96    96.0\n",
+      "97    97.0\n",
+      "98    98.0\n",
+      "99    99.0\n",
+      "Name: c, Length: 100, dtype: float32\n"
+     ]
+    }
+   ],
    "source": [
     "print(type(df['c']))\n",
     "print(df['c'])"
@@ -492,9 +901,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RangeIndex(start=0, stop=100, step=1)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.index"
    ]
@@ -508,9 +928,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     c   d\n",
+      "2  2.0  98\n"
+     ]
+    }
+   ],
    "source": [
     "print(df[df.index == 2])"
    ]
@@ -526,9 +955,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n"
+     ]
+    }
+   ],
    "source": [
     "pandas_df = df.to_pandas()\n",
     "print(type(pandas_df))"
@@ -545,9 +982,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'numpy.ndarray'>\n"
+     ]
+    }
+   ],
    "source": [
     "numpy_array = df.to_pandas().values\n",
     "print(type(numpy_array))"
@@ -585,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,9 +1046,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       c    d\n",
+      "0    0.0  100\n",
+      "1    1.0   99\n",
+      "2    2.0   98\n",
+      "3    3.0   97\n",
+      "4    4.0   96\n",
+      "..   ...  ...\n",
+      "95  95.0    5\n",
+      "96  96.0    4\n",
+      "97  97.0    3\n",
+      "98  98.0    2\n",
+      "99  99.0    1\n",
+      "\n",
+      "[100 rows x 2 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.read_csv('./dataset.csv')\n",
     "print(df)"
@@ -639,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,9 +1115,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     a      b\n",
+      "0  0.0  100.0\n",
+      "1  1.0   99.0\n",
+      "2  2.0   98.0\n",
+      "3  3.0   97.0\n",
+      "4  4.0   96.0\n"
+     ]
+    }
+   ],
    "source": [
     "print(df[0:5])"
    ]
@@ -665,9 +1144,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0      0.0\n",
+      "1      1.0\n",
+      "2      2.0\n",
+      "3      3.0\n",
+      "4      4.0\n",
+      "      ... \n",
+      "95    95.0\n",
+      "96    96.0\n",
+      "97    97.0\n",
+      "98    98.0\n",
+      "99    99.0\n",
+      "Name: a, Length: 100, dtype: float32\n"
+     ]
+    }
+   ],
    "source": [
     "print(df['a'])\n",
     "# print(df.a)  # alternative"
@@ -682,9 +1180,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a      b\n",
+      "0    0.0  100.0\n",
+      "1    1.0   99.0\n",
+      "2    2.0   98.0\n",
+      "3    3.0   97.0\n",
+      "4    4.0   96.0\n",
+      "..   ...    ...\n",
+      "95  95.0    5.0\n",
+      "96  96.0    4.0\n",
+      "97  97.0    3.0\n",
+      "98  98.0    2.0\n",
+      "99  99.0    1.0\n",
+      "\n",
+      "[100 rows x 2 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "print(df[['a', 'b']])"
    ]
@@ -698,9 +1217,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     a\n",
+      "0  0.0\n",
+      "1  1.0\n",
+      "2  2.0\n",
+      "3  3.0\n",
+      "4  4.0\n",
+      "5  5.0\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.loc[0:5, ['a']])\n",
     "# print(df.loc[0:5, ['a', 'b']])  # to select multiple columns, pass in multiple column names"
@@ -717,7 +1250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -728,9 +1261,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a      b      c      d\n",
+      "0    0.0  100.0  100.0  200.0\n",
+      "1    1.0   99.0  101.0  201.0\n",
+      "2    2.0   98.0  102.0  202.0\n",
+      "3    3.0   97.0  103.0  203.0\n",
+      "4    4.0   96.0  104.0  204.0\n",
+      "..   ...    ...    ...    ...\n",
+      "95  95.0    5.0  195.0  295.0\n",
+      "96  96.0    4.0  196.0  296.0\n",
+      "97  97.0    3.0  197.0  297.0\n",
+      "98  98.0    2.0  198.0  298.0\n",
+      "99  99.0    1.0  199.0  299.0\n",
+      "\n",
+      "[100 rows x 4 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "df['d'] = np.arange(200, 300).astype(np.float32)\n",
     "\n",
@@ -739,9 +1293,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a      b      c      d      e\n",
+      "0    0.0  100.0  100.0  200.0  300.0\n",
+      "1    1.0   99.0  101.0  201.0  301.0\n",
+      "2    2.0   98.0  102.0  202.0  302.0\n",
+      "3    3.0   97.0  103.0  203.0  303.0\n",
+      "4    4.0   96.0  104.0  204.0  304.0\n",
+      "..   ...    ...    ...    ...    ...\n",
+      "95  95.0    5.0  195.0  295.0  395.0\n",
+      "96  96.0    4.0  196.0  296.0  396.0\n",
+      "97  97.0    3.0  197.0  297.0  397.0\n",
+      "98  98.0    2.0  198.0  298.0  398.0\n",
+      "99  99.0    1.0  199.0  299.0  399.0\n",
+      "\n",
+      "[100 rows x 5 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "data = np.arange(300, 400).astype(np.float32)\n",
     "# df.add_column('e', data)\n",
@@ -760,7 +1335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,9 +1346,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a      b      c\n",
+      "0    0.0  100.0  100.0\n",
+      "1    1.0   99.0  101.0\n",
+      "2    2.0   98.0  102.0\n",
+      "3    3.0   97.0  103.0\n",
+      "4    4.0   96.0  104.0\n",
+      "..   ...    ...    ...\n",
+      "95  95.0    5.0  195.0\n",
+      "96  96.0    4.0  196.0\n",
+      "97  97.0    3.0  197.0\n",
+      "98  98.0    2.0  198.0\n",
+      "99  99.0    1.0  199.0\n",
+      "\n",
+      "[100 rows x 3 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "# df.drop_column('a')\n",
     "df.drop(['a'], axis=1)\n",
@@ -789,7 +1385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,9 +1396,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original DataFrame:\n",
+      "       a      b      c\n",
+      "0    0.0  100.0  100.0\n",
+      "1    1.0   99.0  101.0\n",
+      "2    2.0   98.0  102.0\n",
+      "3    3.0   97.0  103.0\n",
+      "4    4.0   96.0  104.0\n",
+      "..   ...    ...    ...\n",
+      "95  95.0    5.0  195.0\n",
+      "96  96.0    4.0  196.0\n",
+      "97  97.0    3.0  197.0\n",
+      "98  98.0    2.0  198.0\n",
+      "99  99.0    1.0  199.0\n",
+      "\n",
+      "[100 rows x 3 columns]\n",
+      "-------------------------------------------------------------------------------\n",
+      "New DataFrame:\n",
+      "        b      c\n",
+      "0   100.0  100.0\n",
+      "1    99.0  101.0\n",
+      "2    98.0  102.0\n",
+      "3    97.0  103.0\n",
+      "4    96.0  104.0\n",
+      "..    ...    ...\n",
+      "95    5.0  195.0\n",
+      "96    4.0  196.0\n",
+      "97    3.0  197.0\n",
+      "98    2.0  198.0\n",
+      "99    1.0  199.0\n",
+      "\n",
+      "[100 rows x 2 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "# new_df = df.drop('a')\n",
     "new_df = df.drop(['a'], axis=1)\n",
@@ -822,9 +1456,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original DataFrame:\n",
+      "       a      b      c\n",
+      "0    0.0  100.0  100.0\n",
+      "1    1.0   99.0  101.0\n",
+      "2    2.0   98.0  102.0\n",
+      "3    3.0   97.0  103.0\n",
+      "4    4.0   96.0  104.0\n",
+      "..   ...    ...    ...\n",
+      "95  95.0    5.0  195.0\n",
+      "96  96.0    4.0  196.0\n",
+      "97  97.0    3.0  197.0\n",
+      "98  98.0    2.0  198.0\n",
+      "99  99.0    1.0  199.0\n",
+      "\n",
+      "[100 rows x 3 columns]\n",
+      "-------------------------------------------------------------------------------\n",
+      "New DataFrame:\n",
+      "        c\n",
+      "0   100.0\n",
+      "1   101.0\n",
+      "2   102.0\n",
+      "3   103.0\n",
+      "4   104.0\n",
+      "..    ...\n",
+      "95  195.0\n",
+      "96  196.0\n",
+      "97  197.0\n",
+      "98  198.0\n",
+      "99  199.0\n",
+      "\n",
+      "[100 rows x 1 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "# new_df = df.drop(['a', 'b'])\n",
     "new_df = df.drop(['a', 'b'], axis=1)\n",
@@ -847,9 +1519,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a     b     c\n",
+      "0      0   0.0   0.0\n",
+      "1   <NA>   0.1   0.1\n",
+      "2      2   0.2  <NA>\n",
+      "3      3  <NA>  <NA>\n",
+      "4      4   0.4   0.4\n",
+      "5      5   0.5   0.5\n",
+      "6      6   0.6  <NA>\n",
+      "7      7   0.7   0.7\n",
+      "8      8   0.8   0.8\n",
+      "9   <NA>   0.9   0.9\n",
+      "10    10   1.0   1.0\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.DataFrame({'a': [0, None, 2, 3, 4, 5, 6, 7, 8, None, 10],\n",
     "                     'b': [0.0, 0.1, 0.2, None, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], \n",
@@ -866,9 +1557,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a     b      c\n",
+      "0      0   0.0    0.0\n",
+      "1   <NA>   0.1    0.1\n",
+      "2      2   0.2  999.0\n",
+      "3      3  <NA>  999.0\n",
+      "4      4   0.4    0.4\n",
+      "5      5   0.5    0.5\n",
+      "6      6   0.6  999.0\n",
+      "7      7   0.7    0.7\n",
+      "8      8   0.8    0.8\n",
+      "9   <NA>   0.9    0.9\n",
+      "10    10   1.0    1.0\n"
+     ]
+    }
+   ],
    "source": [
     "df['c'] = df['c'].fillna(999)\n",
     "print(df)"
@@ -876,9 +1586,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     a    b      c\n",
+      "0    0  0.0    0.0\n",
+      "1   -1  0.1    0.1\n",
+      "2    2  0.2  999.0\n",
+      "3    3 -1.0  999.0\n",
+      "4    4  0.4    0.4\n",
+      "5    5  0.5    0.5\n",
+      "6    6  0.6  999.0\n",
+      "7    7  0.7    0.7\n",
+      "8    8  0.8    0.8\n",
+      "9   -1  0.9    0.9\n",
+      "10  10  1.0    1.0\n"
+     ]
+    }
+   ],
    "source": [
     "new_df = df.fillna(-1)\n",
     "print(new_df)"
@@ -895,7 +1624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,9 +1636,250 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>d</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>75</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>75</td>\n",
+       "      <td>25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>76</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>76</td>\n",
+       "      <td>24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>77</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>77</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>78</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>78</td>\n",
+       "      <td>22</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>79</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>79</td>\n",
+       "      <td>21</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>80</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>81</td>\n",
+       "      <td>19</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>82</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>82</td>\n",
+       "      <td>18</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>83</td>\n",
+       "      <td>17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>84</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>84</td>\n",
+       "      <td>16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>85</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>85</td>\n",
+       "      <td>15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>86</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>86</td>\n",
+       "      <td>14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>87</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>87</td>\n",
+       "      <td>13</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>88</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>88</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>89</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>89</td>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>90</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>90</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>91</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>91</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>92</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>92</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>93</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>93</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>94</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>94</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>95</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>96</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>97</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>98</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>99</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    a  b   c   d\n",
+       "75  3  1  75  25\n",
+       "76  3  1  76  24\n",
+       "77  3  1  77  23\n",
+       "78  3  0  78  22\n",
+       "79  3  0  79  21\n",
+       "80  3  0  80  20\n",
+       "81  3  0  81  19\n",
+       "82  3  1  82  18\n",
+       "83  3  0  83  17\n",
+       "84  3  0  84  16\n",
+       "85  3  0  85  15\n",
+       "86  3  1  86  14\n",
+       "87  3  0  87  13\n",
+       "88  3  0  88  12\n",
+       "89  3  1  89  11\n",
+       "90  3  1  90  10\n",
+       "91  3  0  91   9\n",
+       "92  3  1  92   8\n",
+       "93  3  1  93   7\n",
+       "94  3  1  94   6\n",
+       "95  3  1  95   5\n",
+       "96  3  1  96   4\n",
+       "97  3  1  97   3\n",
+       "98  3  0  98   2\n",
+       "99  3  1  99   1"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mask = df['a'] == 3\n",
     "df[mask]"
@@ -928,9 +1898,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b  c    d\n",
+      "0  0  1  0  100\n",
+      "1  0  0  1   99\n",
+      "2  0  0  2   98\n",
+      "3  0  0  3   97\n",
+      "4  0  1  4   96\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.DataFrame({'a': np.repeat([0, 1, 2, 3], 25).astype(np.int32), \n",
     "                     'b': np.random.randint(2, size=100).astype(np.int32), \n",
@@ -941,9 +1924,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    a  b   c  d\n",
+      "99  3  0  99  1\n",
+      "98  3  0  98  2\n",
+      "97  3  1  97  3\n",
+      "96  3  1  96  4\n",
+      "95  3  0  95  5\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.sort_values('d').head())"
    ]
@@ -957,9 +1953,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    a  b   c  d\n",
+      "99  3  0  99  1\n",
+      "98  3  0  98  2\n",
+      "97  3  1  97  3\n",
+      "96  3  1  96  4\n",
+      "95  3  0  95  5\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.sort_values('c', ascending=False).head())"
    ]
@@ -973,9 +1982,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b  c   d\n",
+      "1  0  0  1  99\n",
+      "2  0  0  2  98\n",
+      "3  0  0  3  97\n",
+      "5  0  0  5  95\n",
+      "6  0  0  6  94\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.sort_values(['a', 'b']).head())"
    ]
@@ -989,9 +2011,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sort with all columns specified descending:\n",
+      "    a  b   c   d\n",
+      "78  3  1  78  22\n",
+      "81  3  1  81  19\n",
+      "83  3  1  83  17\n",
+      "84  3  1  84  16\n",
+      "86  3  1  86  14\n",
+      "-------------------------------------------------------------------------------\n",
+      "Sort with both a descending and b ascending:\n",
+      "    a  b   c   d\n",
+      "75  3  0  75  25\n",
+      "76  3  0  76  24\n",
+      "77  3  0  77  23\n",
+      "79  3  0  79  21\n",
+      "80  3  0  80  20\n"
+     ]
+    }
+   ],
    "source": [
     "print('Sort with all columns specified descending:')\n",
     "print(df.sort_values(['a', 'b'], ascending=False).head())\n",
@@ -1011,7 +2055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1023,18 +2067,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "150"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df['a'].sum()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a     150\n",
+      "b      55\n",
+      "c    4950\n",
+      "d    5050\n",
+      "dtype: int64\n"
+     ]
+    }
+   ],
    "source": [
     "print(df.sum())"
    ]
@@ -1050,7 +2117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1062,9 +2129,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0      10\n",
+      "1      11\n",
+      "2      12\n",
+      "3      13\n",
+      "4      14\n",
+      "     ... \n",
+      "95    105\n",
+      "96    106\n",
+      "97    107\n",
+      "98    108\n",
+      "99    109\n",
+      "Name: c, Length: 100, dtype: int64\n"
+     ]
+    }
+   ],
    "source": [
     "def add_ten_to_x(x):\n",
     "    return x + 10\n",
@@ -1083,7 +2169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1095,9 +2181,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0    25\n",
+      "2    25\n",
+      "3    25\n",
+      "1    25\n",
+      "Name: a, dtype: int32\n"
+     ]
+    }
+   ],
    "source": [
     "result = df['a'].value_counts()\n",
     "print(result)"
@@ -1116,7 +2214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1132,9 +2230,141 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>d</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>98</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>96</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>95</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>96</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>97</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>98</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>99</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>200 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    a  b   c    d\n",
+       "0   0  1   0  100\n",
+       "1   0  1   1   99\n",
+       "2   0  1   2   98\n",
+       "3   0  1   3   97\n",
+       "4   0  0   4   96\n",
+       ".. .. ..  ..  ...\n",
+       "95  3  1  95    5\n",
+       "96  3  1  96    4\n",
+       "97  3  0  97    3\n",
+       "98  3  1  98    2\n",
+       "99  3  0  99    1\n",
+       "\n",
+       "[200 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df = cudf.concat([df1, df2], axis=0)\n",
     "df"
@@ -1142,7 +2372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1158,9 +2388,189 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "      <th>b</th>\n",
+       "      <th>c</th>\n",
+       "      <th>d</th>\n",
+       "      <th>e</th>\n",
+       "      <th>f</th>\n",
+       "      <th>g</th>\n",
+       "      <th>h</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>99</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>99</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>98</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>98</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>97</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>96</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>96</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>95</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>95</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>96</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>96</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>97</td>\n",
+       "      <td>3</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>97</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>98</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>98</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>99</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>99</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    a  b   c    d  e  f   g    h\n",
+       "0   0  0   0  100  0  0   0  100\n",
+       "1   0  1   1   99  0  0   1   99\n",
+       "2   0  0   2   98  0  0   2   98\n",
+       "3   0  0   3   97  0  0   3   97\n",
+       "4   0  0   4   96  0  0   4   96\n",
+       ".. .. ..  ..  ... .. ..  ..  ...\n",
+       "95  3  0  95    5  3  0  95    5\n",
+       "96  3  1  96    4  3  1  96    4\n",
+       "97  3  1  97    3  3  1  97    3\n",
+       "98  3  1  98    2  3  0  98    2\n",
+       "99  3  1  99    1  3  0  99    1\n",
+       "\n",
+       "[100 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df = cudf.concat([df1, df2], axis=1)\n",
     "df"
@@ -1182,7 +2592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,9 +2608,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b  c    d   e    f\n",
+      "0  0  1  0  100   0  100\n",
+      "1  0  1  0  100  17   83\n",
+      "2  0  1  0  100  16   84\n",
+      "3  0  1  0  100   1   99\n",
+      "4  0  0  1   99   2   98\n"
+     ]
+    }
+   ],
    "source": [
     "df = df1.merge(df2)\n",
     "print(df.head())"
@@ -1208,9 +2631,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b_x   c   d  b_y   e   f\n",
+      "0  1    1  48  52    0  25  75\n",
+      "1  1    1  48  52    1  48  52\n",
+      "2  1    1  48  52    0  32  68\n",
+      "3  1    1  48  52    1  33  67\n",
+      "4  1    0  49  51    0  25  75\n"
+     ]
+    }
+   ],
    "source": [
     "df = df1.merge(df2, on=['a'])\n",
     "print(df.head())"
@@ -1218,9 +2654,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b   c   d   e    f\n",
+      "0  0  1  16  84   0  100\n",
+      "1  0  1  16  84  16   84\n",
+      "2  0  1  16  84   1   99\n",
+      "3  0  1  16  84   5   95\n",
+      "4  0  1  17  83   0  100\n"
+     ]
+    }
+   ],
    "source": [
     "df = df1.merge(df2, on=['a', 'b'])\n",
     "print(df.head())"
@@ -1228,9 +2677,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b  c    d   e    f\n",
+      "0  0  1  0  100  16   84\n",
+      "1  0  1  0  100   0  100\n",
+      "2  0  1  0  100  17   83\n",
+      "3  0  1  0  100  21   79\n",
+      "4  0  0  1   99  18   82\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.merge(df1, df2)\n",
     "print(df.head())"
@@ -1238,9 +2700,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b_x  c    d  b_y   e    f\n",
+      "0  0    1  0  100    1   0  100\n",
+      "1  0    1  0  100    1  16   84\n",
+      "2  0    1  0  100    1   1   99\n",
+      "3  0    1  0  100    0   2   98\n",
+      "4  0    0  1   99    1   0  100\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.merge(df1, df2, on=['a'])\n",
     "print(df.head())"
@@ -1248,9 +2723,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b  c    d   e    f\n",
+      "0  0  1  0  100   0  100\n",
+      "1  0  1  0  100  16   84\n",
+      "2  0  1  0  100   1   99\n",
+      "3  0  1  0  100  17   83\n",
+      "4  0  0  1   99   2   98\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.merge(df1, df2, on=['a', 'b'])\n",
     "print(df.head())"
@@ -1271,9 +2759,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b  c    d\n",
+      "0  0  0  0  100\n",
+      "1  0  1  1   99\n",
+      "2  0  1  2   98\n",
+      "3  0  0  3   97\n",
+      "4  0  1  4   96\n"
+     ]
+    }
+   ],
    "source": [
     "df = cudf.DataFrame({'a': np.repeat([0, 1, 2, 3], 25).astype(np.int32), \n",
     "                     'b': np.random.randint(2, size=100).astype(np.int32), \n",
@@ -1284,9 +2785,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<cudf.core.groupby.groupby.DataFrameGroupBy at 0x7ff830a70850>"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "grouped_df = df.groupby('a')\n",
     "grouped_df"
@@ -1294,9 +2806,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    b     c     d\n",
+      "a                \n",
+      "0  14   300  2200\n",
+      "2  10  1550   950\n",
+      "3  17  2175   325\n",
+      "1  14   925  1575\n"
+     ]
+    }
+   ],
    "source": [
     "aggregation = grouped_df.sum()\n",
     "print(aggregation)"
@@ -1304,9 +2829,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        c     d\n",
+      "a b            \n",
+      "1 1   505   895\n",
+      "  0   420   680\n",
+      "0 0   116   984\n",
+      "2 1   604   396\n",
+      "0 1   184  1216\n",
+      "2 0   946   554\n",
+      "3 1  1461   239\n",
+      "  0   714    86\n"
+     ]
+    }
+   ],
    "source": [
     "aggregation = df.groupby(['a', 'b']).sum().to_pandas()\n",
     "print(aggregation)"
@@ -1325,9 +2867,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   a  b    c\n",
+      "0  0  0  100\n",
+      "1  0  1   99\n",
+      "2  0  2   98\n",
+      "3  0  3   97\n",
+      "4  0  4   96\n"
+     ]
+    }
+   ],
    "source": [
     "categories = [0, 1, 2, 3]\n",
     "df = cudf.DataFrame({'a': np.repeat(categories, 25).astype(np.int32), \n",
@@ -1338,9 +2893,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   b    c  a__0  a__1  a__2  a__3\n",
+      "0  0  100     1     0     0     0\n",
+      "1  1   99     1     0     0     0\n",
+      "2  2   98     1     0     0     0\n",
+      "3  3   97     1     0     0     0\n",
+      "4  4   96     1     0     0     0\n",
+      "     b  c  a__0  a__1  a__2  a__3\n",
+      "95  95  5     0     0     0     1\n",
+      "96  96  4     0     0     0     1\n",
+      "97  97  3     0     0     0     1\n",
+      "98  98  2     0     0     0     1\n",
+      "99  99  1     0     0     0     1\n"
+     ]
+    }
+   ],
    "source": [
     "result = cudf.get_dummies(df, columns='a', prefix='a_', cats=categories)\n",
     "print(result.head())\n",
@@ -1349,9 +2923,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   b    c  a__0  a__1  a__2  a__3\n",
+      "0  0  100     1     0     0     0\n",
+      "1  1   99     1     0     0     0\n",
+      "2  2   98     1     0     0     0\n",
+      "3  3   97     1     0     0     0\n",
+      "4  4   96     1     0     0     0\n",
+      "     b  c  a__0  a__1  a__2  a__3\n",
+      "95  95  5     0     0     0     1\n",
+      "96  96  4     0     0     0     1\n",
+      "97  97  3     0     0     0     1\n",
+      "98  98  2     0     0     0     1\n",
+      "99  99  1     0     0     0     1\n"
+     ]
+    }
+   ],
    "source": [
     "result = cudf.get_dummies(df, columns='a', prefix='a_', cats=[0, 1, 2])\n",
     "print(result.head())\n",


### PR DESCRIPTION
We've removed `Series.applymap` from cuDF after a period of raising a deprecation warning. It's been replaced by support for `Series.apply`. We should update the notebooks to reflect this.

Closes https://github.com/rapidsai-community/notebooks-contrib/issues/360

~We should not merge this until 22.10~ `Series.apply` will work in 22.08, too.